### PR TITLE
Improve developer experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "scripts": {
     "shadow:watch": "shadow-cljs watch app",
     "shadow:release": "shadow-cljs release app",
-    "postcss:build": "cross-env TAILWIND_MODE=build postcss src/css/tailwind.css -o ./public/css/main.css --verbose",
-    "postcss:watch": "cross-env TAILWIND_MODE=watch postcss src/css/tailwind.css -o ./public/css/main.css --verbose -w",
+    "postcss:build": "postcss src/css/tailwind.css -o ./public/css/main.css --verbose",
+    "postcss:watch": "postcss src/css/tailwind.css -o ./public/css/main.css --verbose -w",
     "postcss:release": "cross-env NODE_ENV=production postcss src/css/tailwind.css -o ./public/css/main.css --verbose",
     "dev": "run-p -l *:watch",
     "release": "run-s *:release"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,9 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  // in prod look at shadow-cljs output file in dev look at runtime, which will change files that are actually compiled; postcss watch should be a whole lot faster
-  content: process.env.NODE_ENV == 'production' ? ["./public/js/main.js"] : ["./public/js/cljs-runtime/*.js"],
+  content: [
+    "./src/main/**/*.cljs"
+  ],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
The first time the project is built, opening the application in the browser till look like this:
![Screenshot from 2023-01-12 23-17-42](https://user-images.githubusercontent.com/1869708/212199628-3fbf1ca6-a9fb-49ad-9a0f-9cb568a5992e.png)

By tracking the ClojureScript files directly this is avoided, and it also boosts speed slightly because wait time for transpiling is entirely avoided.

I've also removed the now deprecated `TAILWIND_MODE` (since Tailwind version 3.0.9).
